### PR TITLE
Fix Ruby 3.0 and active-record-6.0

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -63,6 +63,8 @@ jobs:
         include:
           - ruby: "3.0"
             gemfile: gemfiles/activerecord61.gemfile
+          - ruby: "3.0"
+            gemfile: gemfiles/activerecord60.gemfile
           - ruby: 2.7
             gemfile: gemfiles/activerecord60.gemfile
           - ruby: 2.6

--- a/gemfiles/activerecord60.gemfile
+++ b/gemfiles/activerecord60.gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'activerecord', '~> 6.1.0'
+gem 'activerecord', '~> 6.0.0'
 gem 'bundler'
 gem 'minitest', '>= 5'
 gem 'mocha'

--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -64,7 +64,9 @@ module SafePgMigrations
       end
     end
 
-    def add_index(table_name, column_name, **options)
+    ruby2_keywords def add_index(table_name, column_name, *args_options)
+      options = args_options.last.is_a?(Hash) ? args_options.last : {}
+
       if options[:algorithm] == :default
         options.delete :algorithm
       else


### PR DESCRIPTION
We detected there is an error when we use `ruby 3.0` and `ActiveRecord 6.0` 

CF error: 

```ruby
StatementInsurerTest#test_add_belongs_to:
StandardError: An error has occurred, all later migrations canceled:

wrong number of arguments (given 3, expected 2)
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/lib/safe-pg-migrations/plugins/statement_insurer.rb:67:in `add_index'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/lib/safe-pg-migrations/plugins/useless_statements_logger.rb:15:in `add_index'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/connection_adapters/abstract/schema_definitions.rb:570:in `index'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/connection_adapters/abstract/schema_definitions.rb:152:in `add_to'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:905:in `add_reference'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:890:in `block in method_missing'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:858:in `block in say_with_time'
    /opt/hostedtoolcache/Ruby/3.0.4/x64/lib/ruby/3.0.0/benchmark.rb:293:in `measure'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:858:in `say_with_time'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:879:in `method_missing'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/lib/safe-pg-migrations/base.rb:102:in `block (2 levels) in <module:Migration>'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/test/statement_insurer_test.rb:116:in `change'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:828:in `exec_migration'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/lib/safe-pg-migrations/base.rb:81:in `block in exec_migration'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/lib/safe-pg-migrations/base.rb:34:in `block in setup_and_teardown'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/lib/safe-pg-migrations/plugins/statement_insurer.rb:100:in `with_setting'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/lib/safe-pg-migrations/base.rb:34:in `setup_and_teardown'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/lib/safe-pg-migrations/base.rb:80:in `exec_migration'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:812:in `block (2 levels) in migrate'
    /opt/hostedtoolcache/Ruby/3.0.4/x64/lib/ruby/3.0.0/benchmark.rb:293:in `measure'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:811:in `block in migrate'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:471:in `with_connection'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:810:in `migrate'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:1310:in `block in execute_migration_in_transaction'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:1363:in `ddl_transaction'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:1309:in `execute_migration_in_transaction'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:[128](https://github.com/qonto/safe-pg-migrations/runs/8031200189?check_suite_focus=true#step:5:129)1:in `block in migrate_without_lock'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:1280:in `each'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:1280:in `migrate_without_lock'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:1229:in `block in migrate'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:[138](https://github.com/qonto/safe-pg-migrations/runs/8031200189?check_suite_focus=true#step:5:139)2:in `with_advisory_lock'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/vendor/bundle/ruby/3.0.0/gems/activerecord-6.0.5.1/lib/active_record/migration.rb:1229:in `migrate'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/test/test_helper.rb:58:in `run_migration'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/test/statement_insurer_test.rb:120:in `block in test_add_belongs_to'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/test/test_helper.rb:118:in `record_calls'
    /home/runner/work/safe-pg-migrations/safe-pg-migrations/test/statement_insurer_test.rb:120:in `test_add_belongs_to'
   ```